### PR TITLE
Fix dlt.TranslationModel.load_obj

### DIFF
--- a/dl_translate/_translation_model.py
+++ b/dl_translate/_translation_model.py
@@ -1,4 +1,5 @@
 import os
+import json
 from typing import Union, List, Dict
 
 import transformers
@@ -252,6 +253,9 @@ class TranslationModel:
         torch.save(self._transformers_model, os.path.join(path, "weights.pt"))
         self._tokenizer.save_pretrained(path)
 
+        dlt_config = dict(model_family=self.model_family)
+        json.dump(dlt_config, open(os.path.join(path, "dlt_config.json"), "w"))
+
     @classmethod
     def load_obj(cls, path: str = "saved_model", **kwargs):
         """
@@ -261,5 +265,10 @@ class TranslationModel:
         {{params}}
         {{path}} The directory where your torch model and tokenizer are stored
         """
-        load_dir = os.path.join(path, "weights.pt")
-        return cls(model_or_path=load_dir, tokenizer_path=path, **kwargs)
+        config_prev = json.load(open(os.path.join(path, "dlt_config.json"), "rb"))
+        config_prev.update(kwargs)
+        return cls(
+            model_or_path=os.path.join(path, "weights.pt"),
+            tokenizer_path=path,
+            **config_prev,
+        )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="dl-translate",
-    version="0.2.0",
+    version="0.2.1",
     author="Xing Han Lu",
     author_email="github@xinghanlu.com",
     description="A deep learning-based translation library built on Huggingface transformers",

--- a/tests/long/test_save_load.py
+++ b/tests/long/test_save_load.py
@@ -1,9 +1,15 @@
+import os
+
 import dl_translate as dlt
 
 
 def test_save():
     mt = dlt.TranslationModel()
-    mt.save_obj('saved_model')
+    mt.save_obj("saved_model")
+    assert os.path.exists("saved_model/weights.pt")
+    assert os.path.exists("saved_model/tokenizer_config.json")
+
 
 def test_load():
-    mt = dlt.TranslationModel.load_obj('saved_model')
+    mt = dlt.TranslationModel.load_obj("saved_model")
+    assert isinstance(mt, dlt.TranslationModel)

--- a/tests/long/test_save_load.py
+++ b/tests/long/test_save_load.py
@@ -1,0 +1,9 @@
+import dl_translate as dlt
+
+
+def test_save():
+    mt = dlt.TranslationModel()
+    mt.save_obj('saved_model')
+
+def test_load():
+    mt = dlt.TranslationModel.load_obj('saved_model')


### PR DESCRIPTION
## Added

* New tests for saving and loading.

## Fixed

* `dlt.TranslationModel.load_obj`: Will now work without having to explicitly give the model family.